### PR TITLE
fix: enable curl-cffi impersonation in the yt-dlp install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,16 @@ FROM python:3.13-alpine AS stage-final
 
 COPY --from=stage-bun /usr/local/bin/bun /usr/local/bin/bun
 
+# Install yt-dlp via pip rather than the standalone "yt-dlp" zipimport
+# binary so we can pull the curl-cffi impersonation extra alongside it.
+# Per the yt-dlp README the Unix zipimport build is the one variant that
+# ships *without* curl-cffi, which surfaces as the
+# "no impersonate target is available" warning on every run.
 # hadolint ignore=DL3018
 RUN apk update && \
-    apk add --no-cache curl ffmpeg && \
-    curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp -o /usr/local/bin/yt-dlp && \
-    chmod a+rx /usr/local/bin/yt-dlp
+    apk add --no-cache ffmpeg && \
+    pip install --no-cache-dir --break-system-packages \
+        "yt-dlp[default,curl-cffi]==2026.3.17"
 
 COPY --from=stage-compile /go/src/app/yt-playlist-ripper /
 CMD ["/yt-playlist-ripper"]


### PR DESCRIPTION
## Summary

Every yt-dlp run logged this warning twice on every playlist sync:

> WARNING: The extractor specified to use impersonation for this download, but no impersonate target is available. If you encounter errors, then see https://github.com/yt-dlp/yt-dlp#impersonation for information on installing the required dependencies

The cause is that the Dockerfile was curl'ing in the standalone \`yt-dlp\` Unix zipimport build, which is [the one variant the yt-dlp README explicitly calls out](https://github.com/yt-dlp/yt-dlp#impersonation) as shipping *without* curl-cffi:

> Currently included in most builds except yt-dlp (Unix zipimport binary) and yt-dlp_x86 (Windows 32-bit)

We can't just swap to \`yt-dlp_linux\` because that's a glibc-linked standalone — it won't run on our \`python:3.13-alpine\` (musl) base. The clean fix is a pip install with the impersonation extra; curl-cffi publishes \`musllinux\` wheels so no build deps need adding.

## Change

\`\`\`diff
- apk add --no-cache curl ffmpeg && \\
- curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp -o /usr/local/bin/yt-dlp && \\
- chmod a+rx /usr/local/bin/yt-dlp
+ apk add --no-cache ffmpeg && \\
+ pip install --no-cache-dir --break-system-packages \\
+     \"yt-dlp[default,curl-cffi]==2026.3.17\"
\`\`\`

Version stays pinned at \`2026.3.17\` (same release as before — just sourced from PyPI instead of the GitHub zipimport asset). \`curl\` drops out of the apk install since we no longer need it to fetch the binary.

## Verification

Built locally on \`linux/arm64\`:

\`\`\`
$ yt-dlp --version
2026.03.17

$ yt-dlp --list-impersonate-targets
[info] Available impersonate targets
Client        OS           Source
------------------------------------
Chrome-133    Macos-15     curl_cffi
Chrome-136    Macos-15     curl_cffi
Safari-17.2   Ios-17.2     curl_cffi
Safari-18.0   Ios-18.0     curl_cffi
Safari-18.4   Ios-18.4     curl_cffi
Safari-26.0   Ios-26.0     curl_cffi
Chrome-99     Android-12   curl_cffi
Chrome-131    Android-14   curl_cffi
Tor-14.5      Macos-14     curl_cffi
Edge-99       Windows-10   curl_cffi
Edge-101      Windows-10   curl_cffi
Firefox-133   Macos-14     curl_cffi
\`\`\`

Final image size 509 MB (vs. ~400 MB baseline — curl-cffi's compiled libcurl-impersonate adds ~100 MB, acceptable trade for losing the warning and gaining anti-bot resilience).

## Test plan

- [x] \`docker build\` succeeds on the worktree.
- [x] \`yt-dlp --version\` reports \`2026.03.17\`.
- [x] \`yt-dlp --list-impersonate-targets\` lists curl_cffi sources.
- [ ] Once \`v3.1.x\` (this fix) is published, deploy via lfprocks/k8s and confirm the impersonation WARNING disappears from the next cron tick's logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)