### PR TITLE
fix(ytdl): write channel avatar alongside bootstrap info.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ local provider. The on-disk shape becomes:
 {OUTPUT_ROOT}/
 └── {uploader}/                                       # one Show per channel
     ├── {uploader} - NA - {playlist_title} [{channel_id}].info.json
+    ├── {uploader} - NA - {playlist_title} [{channel_id}].jpg   # channel avatar (Show poster)
     └── Season {YYYY}/
         ├── {uploader} - {YYYYMMDD} - {title} [{id}].mkv
         ├── {uploader} - {YYYYMMDD} - {title} [{id}].info.json
@@ -51,9 +52,11 @@ local provider. The on-disk shape becomes:
 A single playlist can contain videos from many channels — they get split
 into the correct show folder by uploader automatically. For every channel
 that appears in the playlist, a one-shot metadata pass writes the
-channel-level `info.json` at the show root. That bootstrap is gated by a
-sentinel under `{OUTPUT_ROOT}/.bootstrap/` so we don't re-hit YouTube on
-every tick; delete a sentinel to force a re-bootstrap of that channel.
+channel-level `info.json` plus its avatar `.jpg` at the show root. That
+bootstrap is gated by a sentinel under `{OUTPUT_ROOT}/.bootstrap/` so we
+don't re-hit YouTube on every tick; delete a sentinel (or the whole
+`.bootstrap/` directory) to force a re-bootstrap — e.g. to backfill
+missing channel images on a library bootstrapped by an older version.
 
 ```
 docker run \

--- a/internal/ytdl/client.go
+++ b/internal/ytdl/client.go
@@ -249,6 +249,13 @@ func (ytdlClient *YTDLPClient) bootstrapChannel(ctx context.Context, channelID, 
 		WithNoProgress(),
 		WithSkipDownload(),
 		WithWriteInfoJSON(),
+		// Also write the channel banner/avatar alongside the info.json so
+		// the jellyfin-youtube-metadata-plugin's local image provider
+		// finds it. The plugin walks the show root for *.jpg / *.webp
+		// matching a 24-char YouTube channel ID inside [brackets], which
+		// is exactly what our JellyfinInfoTemplate produces.
+		WithWriteThumbnail(),
+		WithConvertThumbnails("jpg"),
 		WithPlaylistItems("0"),
 		WithRestrictFilenames(),
 		WithOutputTemplate(bootstrapTemplate),


### PR DESCRIPTION
## Summary

The jellyfin-youtube-metadata-plugin's local Series image provider walks the show root for `*.jpg` / `*.webp` files matching the regex

```
(?<=\[)[a-zA-Z0-9\-_]{24}(?=\])
```

i.e. a 24-char YouTube channel ID inside `[brackets]`. Our bootstrap step was only writing `--write-info-json`, so the show roots had the metadata file but no sibling image. Result: per-episode thumbnails worked fine but every Show was missing its poster in Jellyfin.

This adds `--write-thumbnail --convert-thumbnails jpg` to the bootstrap yt-dlp invocation so the channel avatar lands at:

```
{OUTPUT_ROOT}/{uploader}/{uploader} - NA - {playlist_title} [{channel_id}].jpg
```

…with the same `[{channel_id}]` 24-char ID inside brackets that the plugin's regex matches.

## Verification

Tested against the live `v3.1.1` image with `rctestflight`'s channel:

```
$ docker run --rm -v /tmp/img-test:/work -w /work --entrypoint /usr/local/bin/yt-dlp \
    ghcr.io/michaelpeterswa/yt-playlist-ripper:v3.1.1 \
    --skip-download --write-info-json --write-thumbnail --convert-thumbnails jpg \
    --playlist-items 0 --restrict-filenames \
    -o "%(uploader)s - NA - %(playlist_title)s [%(channel_id)s].%(ext)s" \
    "https://www.youtube.com/channel/UCq2rNse2XX4Rjzmldv9GqrQ/videos"

[info] Writing playlist metadata as JSON to: rctestflight - NA - rctestflight_-_Videos [UCq2rNse2XX4Rjzmldv9GqrQ].info.json
[info] Downloading playlist thumbnail avatar_uncropped ...
[info] Writing playlist thumbnail avatar_uncropped to: rctestflight - NA - rctestflight_-_Videos [UCq2rNse2XX4Rjzmldv9GqrQ].jpg

$ file rctestflight*.jpg
…JPEG image data, JFIF standard 1.01, … 1378x1379, components 3
```

Plugin's regex matches `UCq2rNse2XX4Rjzmldv9GqrQ` (24 chars) inside `[brackets]`. ✅

## Backfilling existing libraries

The bootstrap is sentinel-gated (`{OUTPUT_ROOT}/.bootstrap/{channelID}.done`), so channels bootstrapped by an earlier build won't re-fire and would keep their show roots image-less. After this release deploys, operators can wipe the sentinel dir to force a one-time re-bootstrap of every channel and pick up the images:

```bash
kubectl -n yt-playlist-ripper exec deploy/yt-playlist-ripper -- rm -rf /media/YouTube/.bootstrap
kubectl -n yt-playlist-ripper rollout restart deploy/yt-playlist-ripper
```

Or wait — the next pod restart with this image won't auto-replay, but the next time the same playlist gets a *new* channel, that one will get its image. Documented in the README.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` / `golangci-lint run ./...` — all green.
- [x] Confirmed empirically against `v3.1.1` image that the flag combo writes a real JPEG channel avatar.
- [ ] After this lands and `v3.1.2` ships, deploy via lfprocks/k8s, wipe `.bootstrap/`, restart pod, scan Jellyfin library — Show posters should populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)