### PR TITLE
Channel artwork backfill + benign bootstrap skip

### DIFF
--- a/IMAGES.md
+++ b/IMAGES.md
@@ -1,0 +1,112 @@
+# Channel Artwork for the Jellyfin Layout
+
+How yt-playlist-ripper gives each channel a **poster** (avatar) and
+**backdrop** (banner) in Jellyfin, and how to backfill artwork for channels
+that were synced before this feature existed.
+
+> **History:** an earlier draft of this document proposed renaming every
+> folder to `Channel [UCxxxx]` and writing `tvshow.nfo` files via a Python
+> script. That approach was **not** what shipped. The Jellyfin layout instead
+> keys off a channel-level `info.json` consumed by the
+> [jellyfin-youtube-metadata-plugin](https://github.com/ankenyr/jellyfin-youtube-metadata-plugin),
+> and folders stay as plain `{uploader}/` (the channel ID lives in the
+> info.json filename, not the folder name). This document describes that
+> shipped design.
+
+---
+
+## How it works
+
+When `JELLYFIN_LAYOUT=true`, every channel that gets synced is first
+*bootstrapped*: a metadata-only yt-dlp pass writes a channel-level
+`info.json` at the show root:
+
+```
+{OUTPUT_ROOT}/{uploader}/
+├── {uploader} - NA - {playlist_title} [{channel_id}].info.json   ← channel metadata
+└── Season {YYYY}/
+    └── {uploader} - {YYYYMMDD} - {title} [{id}].{mkv,info.json,jpg,...}
+```
+
+That channel `info.json` carries a `thumbnails` array describing the
+channel's **avatar** (square) and **banner** (wide) at several resolutions.
+From it we derive two image files written next to the info.json:
+
+- **`poster.*`** — highest-resolution square avatar.
+- **`backdrop.*`** — widest banner (skipped when the channel has none).
+
+These are plain image files that **Jellyfin's built-in local image provider**
+picks up directly — no metadata plugin and no YouTube Data API key required.
+The metadata plugin, if installed, still layers richer series metadata on top.
+
+### Selection rules
+
+Implemented in `internal/channelimage`:
+
+- **Poster:** prefer a squareish thumbnail (aspect ratio ≤ 1.2) whose `id`
+  marks it an avatar; else the largest squareish thumbnail; else whatever is
+  closest to square. The avatar is the channel logo.
+- **Backdrop:** prefer a thumbnail whose `id` marks it a banner; else any
+  sufficiently wide thumbnail (aspect ratio ≥ 2.0). No banner → no backdrop,
+  which Jellyfin handles fine.
+
+The file extension (`.jpg` / `.png` / `.webp`) is chosen from the response
+content type / magic bytes; most YouTube channel art is JPEG.
+
+---
+
+## Going forward: automatic
+
+New channels need no action. After a successful bootstrap, the runtime
+locates the just-written channel `info.json`, selects the avatar/banner, and
+writes `poster.*` / `backdrop.*` into the show root. This is best-effort:
+a download failure is logged but never fails the sync, and existing images
+are never overwritten. The whole bootstrap (info.json + images) is gated by
+the `.bootstrap/{channel_id}.done` sentinel, so it runs once per channel.
+
+To re-fetch a single channel's artwork, delete its sentinel
+(`{OUTPUT_ROOT}/.bootstrap/{channel_id}.done`) and let the next cron tick
+re-bootstrap it.
+
+---
+
+## Backfilling existing channels: `cmd/backfill-images`
+
+Channels synced before this feature have a channel `info.json` but no
+`poster.*` / `backdrop.*`. The `backfill-images` tool reads the `info.json`
+already on disk (no YouTube metadata calls — it only downloads the chosen
+images) and writes the artwork in place.
+
+Dry-run first to see what it would do:
+
+```bash
+go run ./cmd/backfill-images --root /downloads
+```
+
+Then apply:
+
+```bash
+go run ./cmd/backfill-images --root /downloads --apply
+```
+
+| Flag      | Default       | Meaning                                                        |
+|-----------|---------------|----------------------------------------------------------------|
+| `--root`  | `/downloads`  | Library root to scan (the runtime's `OUTPUT_ROOT`).            |
+| `--apply` | `false`       | Actually download images; otherwise dry-run.                  |
+| `--force` | `false`       | Overwrite existing `poster.*` / `backdrop.*` (replaces stale art). |
+
+The tool is **idempotent**: by default it skips any channel that already has
+the corresponding image, so re-running after a partial run is safe. It scans
+for channel-level info.json files (those containing the ` - NA - ` infix) and
+skips the `.bootstrap` / `.archives` state directories.
+
+---
+
+## Verifying in Jellyfin
+
+1. Run the backfill (or let the bootstrap run for new channels).
+2. In Jellyfin, the show root now contains `poster.*` and (when available)
+   `backdrop.*`. Trigger **Refresh Metadata** on the library so the local
+   image provider picks them up.
+3. Confirm each channel shows its avatar as the poster and banner as the
+   backdrop. Channels with no banner show only a poster — expected.

--- a/cmd/backfill-images/main.go
+++ b/cmd/backfill-images/main.go
@@ -1,0 +1,176 @@
+// Command backfill-images walks a Jellyfin-layout yt-playlist-ripper library
+// and writes channel artwork (poster.* + backdrop.*) into each show root,
+// derived from the channel-level info.json already on disk.
+//
+// For every "{uploader} - NA - {playlist_title} [{channel_id}].info.json"
+// the bootstrap pass wrote, it reads the `thumbnails` array, selects the
+// best square avatar (-> poster) and widest banner (-> backdrop), downloads
+// them, and drops them next to the info.json. Jellyfin's built-in local
+// image provider then displays them with no plugin or API quota involved.
+//
+// Run dry-run first:
+//
+//	go run ./cmd/backfill-images --root /downloads
+//
+// Then apply:
+//
+//	go run ./cmd/backfill-images --root /downloads --apply
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/michaelpeterswa/yt-playlist-ripper/internal/channelimage"
+)
+
+// channelInfoMarker is the " - NA - " infix the bootstrap puts in
+// channel-level info.json filenames (from JELLYFIN_INFO_TEMPLATE), which
+// distinguishes them from per-video info.json files.
+const channelInfoMarker = " - NA - "
+
+func main() {
+	var (
+		root  = flag.String("root", "/downloads", "downloads root to scan")
+		apply = flag.Bool("apply", false, "actually download images; otherwise dry-run")
+		force = flag.Bool("force", false, "overwrite existing poster/backdrop images")
+	)
+	flag.Parse()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	if *root == "" {
+		slog.Error("--root is required")
+		os.Exit(2)
+	}
+	if _, err := os.Stat(*root); err != nil {
+		slog.Error("--root not accessible", slog.String("root", *root), slog.String("error", err.Error()))
+		os.Exit(2)
+	}
+
+	infos, err := findChannelInfos(*root)
+	if err != nil {
+		slog.Error("scan failed", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	if len(infos) == 0 {
+		slog.Info("no channel info.json files found; nothing to do")
+		return
+	}
+
+	hc := &http.Client{Timeout: 30 * time.Second}
+	ctx := context.Background()
+
+	var planned, posters, backdrops, skipped int
+	for _, infoPath := range infos {
+		destDir := filepath.Dir(infoPath)
+		thumbs, err := channelimage.ReadThumbnails(infoPath)
+		if err != nil {
+			slog.Warn("could not read thumbnails", slog.String("info_json", infoPath), slog.String("error", err.Error()))
+			continue
+		}
+
+		poster, hasPoster := channelimage.SelectPoster(thumbs)
+		backdrop, hasBackdrop := channelimage.SelectBackdrop(thumbs)
+		if !hasPoster && !hasBackdrop {
+			slog.Warn("no usable thumbnails in info.json", slog.String("info_json", infoPath))
+			continue
+		}
+		planned++
+
+		if !*apply {
+			if hasPoster {
+				dryRun(destDir, channelimage.PosterStem, poster.URL, *force)
+			}
+			if hasBackdrop {
+				dryRun(destDir, channelimage.BackdropStem, backdrop.URL, *force)
+			}
+			continue
+		}
+
+		if hasPoster {
+			if download(ctx, hc, poster.URL, destDir, channelimage.PosterStem, *force) {
+				posters++
+			} else {
+				skipped++
+			}
+		}
+		if hasBackdrop {
+			if download(ctx, hc, backdrop.URL, destDir, channelimage.BackdropStem, *force) {
+				backdrops++
+			} else {
+				skipped++
+			}
+		}
+	}
+
+	if !*apply {
+		slog.Info("dry-run complete; pass --apply to download", slog.Int("channels", planned))
+		return
+	}
+	slog.Info("backfill complete",
+		slog.Int("channels", planned),
+		slog.Int("posters_written", posters),
+		slog.Int("backdrops_written", backdrops),
+		slog.Int("skipped_existing", skipped),
+	)
+}
+
+func dryRun(destDir, stem, url string, force bool) {
+	if existing := channelimage.Existing(destDir, stem); existing != "" && !force {
+		slog.Info("DRY-RUN skip (exists)", slog.String("path", existing))
+		return
+	}
+	slog.Info("DRY-RUN write", slog.String("dest", filepath.Join(destDir, stem+".*")), slog.String("from", url))
+}
+
+func download(ctx context.Context, hc *http.Client, url, destDir, stem string, force bool) bool {
+	path, written, err := channelimage.Download(ctx, hc, url, destDir, stem, force)
+	if err != nil {
+		slog.Warn("download failed", slog.String("stem", stem), slog.String("url", url), slog.String("error", err.Error()))
+		return false
+	}
+	if written {
+		slog.Info("wrote image", slog.String("path", path))
+	} else {
+		slog.Debug("skipped existing image", slog.String("path", path))
+	}
+	return written
+}
+
+// findChannelInfos walks root for channel-level info.json files, skipping the
+// runtime's state directories.
+func findChannelInfos(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			slog.Warn("walk error", slog.String("path", path), slog.String("error", err.Error()))
+			return nil
+		}
+		if d.IsDir() {
+			if name := d.Name(); name == ".bootstrap" || name == ".archives" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, ".info.json") && strings.Contains(base, channelInfoMarker) {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/channelimage/channelimage.go
+++ b/internal/channelimage/channelimage.go
@@ -1,0 +1,234 @@
+// Package channelimage backfills Jellyfin series artwork (poster + backdrop)
+// from the channel-level info.json that the Jellyfin-layout bootstrap writes.
+//
+// The yt-dlp channel dump carries a `thumbnails` array describing the
+// channel's avatar (square) and banner (wide) at several resolutions. We
+// pick the best of each and write them into the show root as poster.* and
+// backdrop.*, which Jellyfin's built-in local image provider consumes
+// directly — no plugin or YouTube Data API quota required.
+package channelimage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Thumbnail mirrors one entry of yt-dlp's `thumbnails` array. Width/Height
+// are zero when yt-dlp omits them (common for the banner), in which case we
+// fall back to the `id` hint ("avatar"/"banner") to classify the image.
+type Thumbnail struct {
+	URL    string `json:"url"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+	ID     string `json:"id"`
+}
+
+// PosterStem and BackdropStem are the on-disk basenames (without extension)
+// Jellyfin recognizes for series Primary and Backdrop images respectively.
+const (
+	PosterStem   = "poster"
+	BackdropStem = "backdrop"
+
+	// squareRatioMax is the largest height:width (or width:height) ratio a
+	// thumbnail may have and still count as the square channel avatar.
+	squareRatioMax = 1.2
+	// wideRatioMin is the smallest width:height ratio a thumbnail must have
+	// to count as the wide channel banner.
+	wideRatioMin = 2.0
+)
+
+// ReadThumbnails parses the `thumbnails` array out of a channel info.json.
+func ReadThumbnails(path string) ([]Thumbnail, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var doc struct {
+		Thumbnails []Thumbnail `json:"thumbnails"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return doc.Thumbnails, nil
+}
+
+// SelectPoster picks the channel avatar: prefer a squareish thumbnail whose
+// id marks it an avatar, then any squareish thumbnail, then whatever is
+// closest to square. Returns false only when no usable thumbnail exists.
+func SelectPoster(thumbs []Thumbnail) (Thumbnail, bool) {
+	if t, ok := maxArea(thumbs, func(t Thumbnail) bool { return isSquare(t) && hasHint(t.ID, "avatar") }); ok {
+		return t, true
+	}
+	if t, ok := maxArea(thumbs, isSquare); ok {
+		return t, true
+	}
+	return closestToSquare(thumbs)
+}
+
+// SelectBackdrop picks the channel banner: prefer a thumbnail whose id marks
+// it a banner, then any sufficiently wide thumbnail. Returns false when the
+// channel has no banner (common) — callers should treat that as normal and
+// skip the backdrop, which Jellyfin handles fine.
+func SelectBackdrop(thumbs []Thumbnail) (Thumbnail, bool) {
+	if t, ok := maxArea(thumbs, func(t Thumbnail) bool {
+		return hasHint(t.ID, "banner") && (isWide(t) || !hasDims(t))
+	}); ok {
+		return t, true
+	}
+	return maxArea(thumbs, isWide)
+}
+
+func hasDims(t Thumbnail) bool { return t.Width > 0 && t.Height > 0 }
+
+func isSquare(t Thumbnail) bool {
+	if !hasDims(t) {
+		return false
+	}
+	hi, lo := t.Width, t.Height
+	if lo > hi {
+		hi, lo = lo, hi
+	}
+	return float64(hi)/float64(lo) <= squareRatioMax
+}
+
+func isWide(t Thumbnail) bool {
+	if !hasDims(t) {
+		return false
+	}
+	return float64(t.Width)/float64(t.Height) >= wideRatioMin
+}
+
+func hasHint(id, sub string) bool {
+	return strings.Contains(strings.ToLower(id), sub)
+}
+
+// maxArea returns the URL-bearing thumbnail with the greatest pixel area
+// among those satisfying pred. Thumbnails without dimensions have area 0 but
+// are still eligible (used for dimensionless banners).
+func maxArea(thumbs []Thumbnail, pred func(Thumbnail) bool) (Thumbnail, bool) {
+	var best Thumbnail
+	var bestArea int64 = -1
+	found := false
+	for _, t := range thumbs {
+		if t.URL == "" || !pred(t) {
+			continue
+		}
+		area := int64(t.Width) * int64(t.Height)
+		if area > bestArea {
+			bestArea, best, found = area, t, true
+		}
+	}
+	return best, found
+}
+
+// closestToSquare is the last-resort poster fallback: the dimensioned
+// thumbnail with the most square aspect ratio, breaking ties by area.
+func closestToSquare(thumbs []Thumbnail) (Thumbnail, bool) {
+	var best Thumbnail
+	bestRatio := math.MaxFloat64
+	var bestArea int64 = -1
+	found := false
+	for _, t := range thumbs {
+		if t.URL == "" || !hasDims(t) {
+			continue
+		}
+		hi, lo := t.Width, t.Height
+		if lo > hi {
+			hi, lo = lo, hi
+		}
+		ratio := float64(hi) / float64(lo)
+		area := int64(t.Width) * int64(t.Height)
+		if ratio < bestRatio || (ratio == bestRatio && area > bestArea) {
+			bestRatio, bestArea, best, found = ratio, area, t, true
+		}
+	}
+	return best, found
+}
+
+// Existing returns the path of an already-written image with the given stem
+// (poster/backdrop) in destDir, trying the known image extensions, or ""
+// when none exists. Used for idempotency.
+func Existing(destDir, stem string) string {
+	for _, ext := range []string{".jpg", ".jpeg", ".png", ".webp"} {
+		p := filepath.Join(destDir, stem+ext)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// Download fetches url and writes it into destDir as stem + the extension
+// implied by the response content type / magic bytes. It is a no-op (written
+// == false) when an image with that stem already exists and force is false.
+func Download(ctx context.Context, hc *http.Client, url, destDir, stem string, force bool) (path string, written bool, err error) {
+	if existing := Existing(destDir, stem); existing != "" && !force {
+		return existing, false, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", false, fmt.Errorf("get %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", false, fmt.Errorf("get %s: status %d", url, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", false, fmt.Errorf("read body %s: %w", url, err)
+	}
+
+	ext := imageExt(resp.Header.Get("Content-Type"), body)
+	dst := filepath.Join(destDir, stem+ext)
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return "", false, fmt.Errorf("mkdir %s: %w", destDir, err)
+	}
+	// When forcing, clear any prior image with this stem (possibly a
+	// different extension) so we don't leave two posters behind.
+	if force {
+		if old := Existing(destDir, stem); old != "" && old != dst {
+			_ = os.Remove(old)
+		}
+	}
+	if err := os.WriteFile(dst, body, 0o644); err != nil {
+		return "", false, fmt.Errorf("write %s: %w", dst, err)
+	}
+	return dst, true, nil
+}
+
+// imageExt maps a content type (falling back to magic-byte sniffing) to a
+// Jellyfin-friendly extension, defaulting to .jpg since most YouTube channel
+// art is JPEG.
+func imageExt(contentType string, body []byte) string {
+	switch ct := strings.ToLower(contentType); {
+	case strings.Contains(ct, "png"):
+		return ".png"
+	case strings.Contains(ct, "webp"):
+		return ".webp"
+	case strings.Contains(ct, "jpeg"), strings.Contains(ct, "jpg"):
+		return ".jpg"
+	}
+	switch {
+	case len(body) >= 2 && body[0] == 0xFF && body[1] == 0xD8:
+		return ".jpg"
+	case len(body) >= 8 && string(body[:8]) == "\x89PNG\r\n\x1a\n":
+		return ".png"
+	case len(body) >= 12 && string(body[:4]) == "RIFF" && string(body[8:12]) == "WEBP":
+		return ".webp"
+	}
+	return ".jpg"
+}

--- a/internal/channelimage/channelimage_test.go
+++ b/internal/channelimage/channelimage_test.go
@@ -1,0 +1,186 @@
+package channelimage
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// realisticThumbs mirrors the shape of a yt-dlp channel dump: several square
+// avatar variants (some id-tagged), one wide banner, and a couple of
+// dimensionless entries.
+func realisticThumbs() []Thumbnail {
+	return []Thumbnail{
+		{URL: "https://x/avatar48", Width: 48, Height: 48, ID: "0"},
+		{URL: "https://x/avatar160", Width: 160, Height: 160, ID: "1"},
+		{URL: "https://x/avatar900", Width: 900, Height: 900, ID: "avatar_uncropped"},
+		{URL: "https://x/banner", Width: 2560, Height: 424, ID: "banner_uncropped"},
+	}
+}
+
+func TestSelectPosterPrefersSquareAvatar(t *testing.T) {
+	got, ok := SelectPoster(realisticThumbs())
+	if !ok {
+		t.Fatal("expected a poster")
+	}
+	if got.URL != "https://x/avatar900" {
+		t.Errorf("poster = %q; want the 900x900 avatar", got.URL)
+	}
+}
+
+func TestSelectPosterFallsBackToLargestSquare(t *testing.T) {
+	// No avatar-tagged thumbnails: still want the biggest square one.
+	thumbs := []Thumbnail{
+		{URL: "https://x/s100", Width: 100, Height: 100, ID: "a"},
+		{URL: "https://x/s512", Width: 512, Height: 512, ID: "b"},
+		{URL: "https://x/wide", Width: 1280, Height: 200, ID: "banner_uncropped"},
+	}
+	got, ok := SelectPoster(thumbs)
+	if !ok {
+		t.Fatal("expected a poster")
+	}
+	if got.URL != "https://x/s512" {
+		t.Errorf("poster = %q; want the 512 square", got.URL)
+	}
+}
+
+func TestSelectPosterClosestToSquareWhenNoneSquare(t *testing.T) {
+	thumbs := []Thumbnail{
+		{URL: "https://x/2to1", Width: 200, Height: 100, ID: "a"},   // ratio 2.0
+		{URL: "https://x/4to3", Width: 400, Height: 300, ID: "b"},   // ratio 1.33
+		{URL: "https://x/16to9", Width: 1600, Height: 900, ID: "c"}, // ratio 1.78
+	}
+	got, ok := SelectPoster(thumbs)
+	if !ok {
+		t.Fatal("expected a poster")
+	}
+	if got.URL != "https://x/4to3" {
+		t.Errorf("poster = %q; want the 4:3 (closest to square)", got.URL)
+	}
+}
+
+func TestSelectBackdropPrefersBanner(t *testing.T) {
+	got, ok := SelectBackdrop(realisticThumbs())
+	if !ok {
+		t.Fatal("expected a backdrop")
+	}
+	if got.URL != "https://x/banner" {
+		t.Errorf("backdrop = %q; want the banner", got.URL)
+	}
+}
+
+func TestSelectBackdropDimensionlessBanner(t *testing.T) {
+	// Banner with no width/height should still be chosen via its id hint.
+	thumbs := []Thumbnail{
+		{URL: "https://x/avatar", Width: 900, Height: 900, ID: "avatar_uncropped"},
+		{URL: "https://x/banner", ID: "banner_uncropped"},
+	}
+	got, ok := SelectBackdrop(thumbs)
+	if !ok {
+		t.Fatal("expected a backdrop")
+	}
+	if got.URL != "https://x/banner" {
+		t.Errorf("backdrop = %q; want the dimensionless banner", got.URL)
+	}
+}
+
+func TestSelectBackdropNoneWhenOnlySquares(t *testing.T) {
+	thumbs := []Thumbnail{
+		{URL: "https://x/a", Width: 100, Height: 100, ID: "0"},
+		{URL: "https://x/b", Width: 900, Height: 900, ID: "avatar_uncropped"},
+	}
+	if _, ok := SelectBackdrop(thumbs); ok {
+		t.Error("expected no backdrop when the channel has no banner")
+	}
+}
+
+func TestReadThumbnails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Chan - NA - Videos [UCabc].info.json")
+	body := `{"id":"NA","uploader":"Chan","thumbnails":[
+		{"url":"https://x/a","width":900,"height":900,"id":"avatar_uncropped"},
+		{"url":"https://x/b","width":2560,"height":424,"id":"banner_uncropped"}
+	]}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	thumbs, err := ReadThumbnails(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(thumbs) != 2 {
+		t.Fatalf("got %d thumbnails, want 2", len(thumbs))
+	}
+}
+
+func TestDownloadWritesAndIsIdempotent(t *testing.T) {
+	jpeg := []byte{0xFF, 0xD8, 0xFF, 0xE0, 'd', 'a', 't', 'a'}
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write(jpeg)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	hc := &http.Client{Timeout: 5 * time.Second}
+	ctx := context.Background()
+
+	path, written, err := Download(ctx, hc, srv.URL, dir, PosterStem, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !written {
+		t.Fatal("expected first download to write")
+	}
+	if filepath.Base(path) != "poster.jpg" {
+		t.Errorf("path = %q; want poster.jpg", path)
+	}
+
+	// Second call without force must be a no-op (no extra HTTP hit).
+	_, written2, err := Download(ctx, hc, srv.URL, dir, PosterStem, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written2 {
+		t.Error("expected second download to skip (idempotent)")
+	}
+	if hits != 1 {
+		t.Errorf("server hit %d times; want 1 (idempotent skip should not re-fetch)", hits)
+	}
+}
+
+func TestDownloadForceOverwrites(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("\x89PNG\r\n\x1a\nrest"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	// Pre-existing jpg poster from a prior run.
+	if err := os.WriteFile(filepath.Join(dir, "poster.jpg"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hc := &http.Client{Timeout: 5 * time.Second}
+	path, written, err := Download(context.Background(), hc, srv.URL, dir, PosterStem, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !written {
+		t.Fatal("expected force download to write")
+	}
+	if filepath.Base(path) != "poster.png" {
+		t.Errorf("path = %q; want poster.png", path)
+	}
+	// The stale poster.jpg should have been removed to avoid two posters.
+	if _, err := os.Stat(filepath.Join(dir, "poster.jpg")); err == nil {
+		t.Error("expected stale poster.jpg to be removed on force")
+	}
+}

--- a/internal/ytdl/bootstrap_test.go
+++ b/internal/ytdl/bootstrap_test.go
@@ -1,0 +1,71 @@
+package ytdl
+
+import "testing"
+
+func TestBenignBootstrapSkip(t *testing.T) {
+	cases := []struct {
+		name string
+		res  execResult
+		want bool
+	}{
+		{
+			name: "no errors at all is not a benign skip",
+			res:  execResult{sawError: false},
+			want: false,
+		},
+		{
+			name: "only the no-videos-tab error is benign",
+			res: execResult{
+				sawError: true,
+				capturedIssues: []string{
+					"WARNING: [youtube:tab] YouTube said: INFO - 1 unavailable video is hidden",
+					"ERROR: [youtube:tab] UCSBcH7rSDGSPUAhBbsLWCyQ: This channel does not have a videos tab",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "case-insensitive match",
+			res: execResult{
+				sawError:       true,
+				capturedIssues: []string{"ERROR: This channel does NOT have a Videos tab"},
+			},
+			want: true,
+		},
+		{
+			name: "a real error alongside the benign one is not benign",
+			res: execResult{
+				sawError: true,
+				capturedIssues: []string{
+					"ERROR: [youtube:tab] UCabc: This channel does not have a videos tab",
+					"ERROR: unable to download webpage: HTTP Error 403: Forbidden",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "an unrelated error is not benign",
+			res: execResult{
+				sawError:       true,
+				capturedIssues: []string{"ERROR: unable to download webpage: HTTP Error 403: Forbidden"},
+			},
+			want: false,
+		},
+		{
+			name: "sawError set but only warnings captured is not benign",
+			res: execResult{
+				sawError:       true,
+				capturedIssues: []string{"WARNING: something cosmetic"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := benignBootstrapSkip(tc.res); got != tc.want {
+				t.Errorf("benignBootstrapSkip() = %v; want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ytdl/client.go
+++ b/internal/ytdl/client.go
@@ -263,11 +263,68 @@ func (ytdlClient *YTDLPClient) bootstrapChannel(ctx context.Context, channelID, 
 	}
 
 	res := ytdlClient.execute(ctx, label, NewCommand("yt-dlp", opts...))
+
+	// A channel with no public Videos tab (Shorts/Live-only, or uploads
+	// hidden) makes yt-dlp exit non-zero with a known, benign ERROR. There's
+	// nothing to bootstrap, so skip it quietly instead of logging an ERROR
+	// and firing a failure notification. We don't write the sentinel: if the
+	// channel later gains a Videos tab, a future tick will pick it up.
+	if benignBootstrapSkip(res) {
+		slog.Info("skipping channel bootstrap: channel has no Videos tab",
+			slog.String("channel", channelID),
+			slog.String("target", label),
+		)
+		return false
+	}
+
 	ytdlClient.reportResult(ctx, label, res)
 	if res.waitErr == nil && !res.sawError {
 		ytdlClient.writeChannelImages(ctx, channelID)
 		ytdlClient.markChannelBootstrapped(channelID)
 		return true
+	}
+	return false
+}
+
+// benignBootstrapErrorMarkers are substrings of yt-dlp ERROR lines that, when
+// they are the *only* errors a channel bootstrap produced, indicate an
+// expected, skippable condition rather than a real failure. The bootstrap
+// always targets a channel's /videos tab, so "no Videos tab" is the relevant
+// case.
+var benignBootstrapErrorMarkers = []string{
+	"does not have a videos tab",
+}
+
+// benignBootstrapSkip reports whether a bootstrap execResult failed solely
+// because of a benign, expected condition (see benignBootstrapErrorMarkers).
+// It returns false when there were no errors at all, or when any captured
+// ERROR line is something other than a benign marker — so genuinely broken
+// invocations still surface as real failures.
+func benignBootstrapSkip(r execResult) bool {
+	if !r.sawError {
+		return false
+	}
+	sawBenign := false
+	for _, line := range r.capturedIssues {
+		if !strings.HasPrefix(line, "ERROR:") {
+			continue // WARNING lines don't affect the classification
+		}
+		if matchesAny(line, benignBootstrapErrorMarkers) {
+			sawBenign = true
+			continue
+		}
+		return false // a real error is present alongside the benign one
+	}
+	return sawBenign
+}
+
+// matchesAny reports whether line contains any of markers, case-insensitively.
+func matchesAny(line string, markers []string) bool {
+	lower := strings.ToLower(line)
+	for _, m := range markers {
+		if strings.Contains(lower, m) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/ytdl/client.go
+++ b/internal/ytdl/client.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/michaelpeterswa/yt-playlist-ripper/internal/channelimage"
 	"github.com/michaelpeterswa/yt-playlist-ripper/internal/config"
 	"github.com/michaelpeterswa/yt-playlist-ripper/internal/lockmap"
 	"github.com/michaelpeterswa/yt-playlist-ripper/internal/notifier"
@@ -262,10 +265,54 @@ func (ytdlClient *YTDLPClient) bootstrapChannel(ctx context.Context, channelID, 
 	res := ytdlClient.execute(ctx, label, NewCommand("yt-dlp", opts...))
 	ytdlClient.reportResult(ctx, label, res)
 	if res.waitErr == nil && !res.sawError {
+		ytdlClient.writeChannelImages(ctx, channelID)
 		ytdlClient.markChannelBootstrapped(channelID)
 		return true
 	}
 	return false
+}
+
+// writeChannelImages derives poster.*/backdrop.* for a channel from the
+// info.json the bootstrap pass just wrote and drops them into the show root,
+// so Jellyfin's local image provider can display channel art without the
+// metadata plugin or a YouTube Data API key. Best-effort: any failure is
+// logged and does not fail the bootstrap (the sentinel still gets written).
+func (ytdlClient *YTDLPClient) writeChannelImages(ctx context.Context, channelID string) {
+	// The bootstrap output template lands the info.json one level under the
+	// output root as "{uploader}/{uploader} - NA - {title} [{channelID}].info.json".
+	pattern := filepath.Join(ytdlClient.c.OutputRoot, "*", "* - NA - *["+channelID+"].info.json")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		slog.Warn("could not locate channel info.json for image backfill",
+			slog.String("channel", channelID),
+			slog.String("pattern", pattern),
+		)
+		return
+	}
+
+	infoPath := matches[0]
+	destDir := filepath.Dir(infoPath)
+	thumbs, err := channelimage.ReadThumbnails(infoPath)
+	if err != nil {
+		slog.Warn("could not read channel thumbnails", slog.String("info_json", infoPath), slog.String("error", err.Error()))
+		return
+	}
+
+	hc := &http.Client{Timeout: 30 * time.Second}
+	if poster, ok := channelimage.SelectPoster(thumbs); ok {
+		if path, written, err := channelimage.Download(ctx, hc, poster.URL, destDir, channelimage.PosterStem, false); err != nil {
+			slog.Warn("could not write channel poster", slog.String("channel", channelID), slog.String("error", err.Error()))
+		} else if written {
+			slog.Info("wrote channel poster", slog.String("path", path))
+		}
+	}
+	if backdrop, ok := channelimage.SelectBackdrop(thumbs); ok {
+		if path, written, err := channelimage.Download(ctx, hc, backdrop.URL, destDir, channelimage.BackdropStem, false); err != nil {
+			slog.Warn("could not write channel backdrop", slog.String("channel", channelID), slog.String("error", err.Error()))
+		} else if written {
+			slog.Info("wrote channel backdrop", slog.String("path", path))
+		}
+	}
 }
 
 // enumeratePlaylistChannels lists the unique channel IDs that appear in a


### PR DESCRIPTION
Two related changes to the Jellyfin layout, split into one commit each.

## 1. `feat(jellyfin): backfill channel poster/backdrop artwork`

The Jellyfin layout already writes a channel-level `info.json` per channel, but never wrote any image files — so channels had no poster/backdrop unless the metadata plugin (which depends on a YouTube Data API key and was previously broken) fetched them.

This derives artwork directly from the `thumbnails` array in that on-disk `info.json`: best square avatar → `poster.*`, widest banner → `backdrop.*`, written into the show root where Jellyfin's **built-in local image provider** consumes them — no plugin, no API quota.

- `internal/channelimage`: thumbnail selection + content-typed download. **Stdlib-only**, idempotent (skips existing; `--force` overwrites).
- `cmd/backfill-images`: operator tool for existing channels. Dry-run by default, `--apply` to commit, `--force` to overwrite.
  ```bash
  go run ./cmd/backfill-images --root /downloads          # dry-run
  go run ./cmd/backfill-images --root /downloads --apply
  ```
- `bootstrapChannel` now self-populates images for **new** channels automatically (best-effort; never fails the sync).
- `IMAGES.md` rewritten to document the shipped design (the prior draft described an abandoned folder-rename/NFO approach).

Channel→image association is purely by file location: each `info.json` lives in its own channel's folder and carries its own thumbnails, so images are written back into the same directory — no cross-channel matching.

## 2. `fix(ytdl): treat "no Videos tab" channel bootstrap as a skip, not an error`

A channel with no public Videos tab (Shorts/Live-only, or hidden uploads) makes the bootstrap yt-dlp call exit non-zero with a benign `ERROR: ... does not have a videos tab`. The runner logged this at ERROR and fired a Pushover failure notification even though the run continues and all playlists finish.

Now classified explicitly: when the only captured ERROR lines are that benign marker, it logs at INFO and skips the channel. **Any other error — alone or alongside the benign one — still surfaces as a real ERROR**, so broken invocations aren't masked. The sentinel is left unwritten, so a channel that later gains a Videos tab is picked up on a future tick. No config knob — the condition is unconditionally benign for a `/videos` bootstrap.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test ./...` green, including new `internal/channelimage` and `internal/ytdl/bootstrap_test.go`
- `golangci-lint run` — 0 issues
- Each commit builds and tests independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)